### PR TITLE
Fix for forEach - vowelCount - returning uppercase letters

### DIFF
--- a/advanced-array-methods/forEach/forEach-exercises.js
+++ b/advanced-array-methods/forEach/forEach-exercises.js
@@ -1,51 +1,51 @@
 // forEach
 
-function doubleValues(arr){
-    var newArr = [];
-    arr.forEach(function(val){
-        newArr.push(val * 2)
-    })
-    return newArr;
+function doubleValues(arr) {
+   var newArr = [];
+   arr.forEach(function(val) {
+      newArr.push(val * 2)
+   })
+   return newArr;
 }
 
-function onlyEvenValues(arr){
-    var newArr = [];
-    arr.forEach(function(val){
-        if(val % 2 === 0){
-            newArr.push(val)
-        }
-    })
-    return newArr;
+function onlyEvenValues(arr) {
+   var newArr = [];
+   arr.forEach(function(val) {
+      if (val % 2 === 0) {
+         newArr.push(val)
+      }
+   })
+   return newArr;
 }
 
-function showFirstAndLast(arr){
-    var newArr = [];
-    arr.forEach(function(val){
-        newArr.push(val[0] + val[val.length-1])
-    });
-    return newArr;
+function showFirstAndLast(arr) {
+   var newArr = [];
+   arr.forEach(function(val) {
+      newArr.push(val[0] + val[val.length - 1])
+   });
+   return newArr;
 }
 
-function addKeyAndValue(arr,key,value){
-    arr.forEach(function(val){
-        val[key] = value;
-    });
-    return arr;
+function addKeyAndValue(arr, key, value) {
+   arr.forEach(function(val) {
+      val[key] = value;
+   });
+   return arr;
 }
 
-function vowelCount(str){
-    var splitArr = str.split("");
-    var obj = {};
-    var vowels = "aeiou";
+function vowelCount(str) {
+   var splitArr = str.toLowerCase().split("");
+   var obj = {};
+   var vowels = "aeiou";
 
-    splitArr.forEach(function(letter){
-        if(vowels.indexOf(letter.toLowerCase()) !== -1){
-            if(obj[letter]){
-                obj[letter]++;
-            } else{
-                obj[letter] = 1;
-            }
-        }
-    });
-    return obj;
+   splitArr.forEach(function(letter) {
+      if (vowels.indexOf(letter) !== -1) {
+         if (obj[letter]) {
+            obj[letter]++;
+         } else {
+            obj[letter] = 1;
+         }
+      }
+   });
+   return obj;
 }

--- a/advanced-array-methods/forEach/forEach-exercises.js
+++ b/advanced-array-methods/forEach/forEach-exercises.js
@@ -1,51 +1,51 @@
 // forEach
 
-function doubleValues(arr) {
-   var newArr = [];
-   arr.forEach(function(val) {
-      newArr.push(val * 2)
-   })
-   return newArr;
+function doubleValues(arr){
+    var newArr = [];
+    arr.forEach(function(val){
+        newArr.push(val * 2)
+    })
+    return newArr;
 }
 
-function onlyEvenValues(arr) {
-   var newArr = [];
-   arr.forEach(function(val) {
-      if (val % 2 === 0) {
-         newArr.push(val)
-      }
-   })
-   return newArr;
+function onlyEvenValues(arr){
+    var newArr = [];
+    arr.forEach(function(val){
+        if(val % 2 === 0){
+            newArr.push(val)
+        }
+    })
+    return newArr;
 }
 
-function showFirstAndLast(arr) {
-   var newArr = [];
-   arr.forEach(function(val) {
-      newArr.push(val[0] + val[val.length - 1])
-   });
-   return newArr;
+function showFirstAndLast(arr){
+    var newArr = [];
+    arr.forEach(function(val){
+        newArr.push(val[0] + val[val.length-1])
+    });
+    return newArr;
 }
 
-function addKeyAndValue(arr, key, value) {
-   arr.forEach(function(val) {
-      val[key] = value;
-   });
-   return arr;
+function addKeyAndValue(arr,key,value){
+    arr.forEach(function(val){
+        val[key] = value;
+    });
+    return arr;
 }
 
-function vowelCount(str) {
-   var splitArr = str.toLowerCase().split("");
-   var obj = {};
-   var vowels = "aeiou";
+function vowelCount(str){
+    var splitArr = str.toLowerCase().split("");
+    var obj = {};
+    var vowels = "aeiou";
 
-   splitArr.forEach(function(letter) {
-      if (vowels.indexOf(letter) !== -1) {
-         if (obj[letter]) {
-            obj[letter]++;
-         } else {
-            obj[letter] = 1;
-         }
-      }
-   });
-   return obj;
+    splitArr.forEach(function(letter){
+        if(vowels.indexOf(letter) !== -1){
+            if(obj[letter]){
+                obj[letter]++;
+            } else{
+                obj[letter] = 1;
+            }
+        }
+    });
+    return obj;
 }


### PR DESCRIPTION
Here is my fix for the vowelCount function returning uppercase letters in the array. The string is lowercased when the string is split. The ".toLowerCase" was also removed from the forEach loop, as it's redundant now.