### PR TITLE
Update call-apply-bind-exercises.js

### DIFF
--- a/closures-and-keyword-this/call-apply-bind/call-apply-bind-exercises.js
+++ b/closures-and-keyword-this/call-apply-bind/call-apply-bind-exercises.js
@@ -32,7 +32,7 @@ function once(fn, thisArg){
 }
 
 function flip(fn, thisArg){
-    var outerArgs = [].slice.call(arguments,2)
+    var outerArgs = [].slice.call(arguments[2])
     return function(){
         var innerArgs = [].slice.call(arguments)
         var allArgs = outerArgs.concat(innerArgs).slice(0, fn.length)
@@ -41,7 +41,7 @@ function flip(fn, thisArg){
 }
 
 function bind(fn, thisArg){
-    var outerArgs = [].slice.call(arguments,2)
+    var outerArgs = [].slice.call(arguments[2])
     return function(){
         var innerArgs = [].slice.call(arguments)
         var allArgs = outerArgs.concat(innerArgs)


### PR DESCRIPTION
Change the arguments keyword to bracket notation in the outerArgs variable of the once and bind functions thereby pointing to the 3rd arguments and beyond in the agruments array like object rather than adding a 2 as a second argument to the call method.